### PR TITLE
Make the abstract class readable as well

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -94,7 +94,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 7.4
+          php-version: 8.0
           coverage: none
 
       - name: Get composer cache directory

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -104,7 +104,7 @@ jobs:
       - name: Install dependencies
         run: |
           composer install --no-interaction --no-progress --prefer-dist
-          composer require --dev maglnet/composer-require-checker ^2.0
+          composer require --dev maglnet/composer-require-checker ^3.0
 
       - name: Run composer-require-checker
-        run: ./vendor/bin/composer-require-checker check ./composer.json
+        run: ./vendor/bin/composer-require-checker

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     },
     "require-dev": {
         "ext-pdo": "*",
-        "phpunit/phpunit": "^9.2",
+        "phpunit/phpunit": "^9.5",
         "bamarni/composer-bin-plugin": "^1.4"
     },
     "autoload": {
@@ -37,7 +37,7 @@
         "post-update-cmd": ["@composer bin all update --ansi"],
         "test": "./vendor/bin/phpunit",
         "tests": ["@cs", "@test", "@sa"],
-        "coverage": ["php -dzend_extension=xdebug.so ./vendor/bin/phpunit --coverage-text --coverage-html=build/coverage"],
+        "coverage": ["php -dzend_extension=xdebug.so -dxdebug.mode=coverage ./vendor/bin/phpunit --coverage-text --coverage-html=build/coverage"],
         "pcov": ["php -dextension=pcov.so -d pcov.enabled=1 ./vendor/bin/phpunit --coverage-text --coverage-html=build/coverage  --coverage-clover=coverage.xml"],
         "cs": ["phpcs --standard=./phpcs.xml src tests"],
         "cs-fix": ["./vendor/bin/phpcbf src tests"],

--- a/src/AttributeReader.php
+++ b/src/AttributeReader.php
@@ -10,9 +10,6 @@ use ReflectionClass;
 use ReflectionMethod;
 use ReflectionProperty;
 
-use function interface_exists;
-use function is_subclass_of;
-
 final class AttributeReader implements Reader
 {
     /**

--- a/src/AttributeReader.php
+++ b/src/AttributeReader.php
@@ -72,10 +72,6 @@ final class AttributeReader implements Reader
             return $object;
         }
 
-        if (interface_exists($annotationName)) {
-            return $this->seekInterface($class->getAttributes(), $annotationName);
-        }
-
         return null;
     }
 
@@ -96,10 +92,6 @@ final class AttributeReader implements Reader
             $object = $attributes[0]->newInstance();
 
             return $object;
-        }
-
-        if (interface_exists($annotationName)) {
-            return $this->seekInterface($method->getAttributes(), $annotationName);
         }
 
         return null;
@@ -136,32 +128,6 @@ final class AttributeReader implements Reader
             $object = $attributes[0]->newInstance();
 
             return $object;
-        }
-
-        if (interface_exists($annotationName)) {
-            return $this->seekInterface($property->getAttributes(), $annotationName);
-        }
-
-        return null;
-    }
-
-    /**
-     * @param array<ReflectionAttribute> $attributes
-     * @param class-string<T>            $interface
-     *
-     * @return T|null
-     *
-     * @template T of object
-     */
-    private function seekInterface(array $attributes, string $interface): ?object
-    {
-        foreach ($attributes as $attribute) {
-            if (is_subclass_of($attribute->getName(), $interface)) {
-                /** @var T $object */
-                $object =  $attribute->newInstance();
-
-                return $object;
-            }
         }
 
         return null;

--- a/src/AttributeReader.php
+++ b/src/AttributeReader.php
@@ -64,7 +64,7 @@ final class AttributeReader implements Reader
      */
     public function getClassAnnotation(ReflectionClass $class, $annotationName): ?object
     {
-        $attributes = $class->getAttributes($annotationName);
+        $attributes = $class->getAttributes($annotationName, ReflectionAttribute::IS_INSTANCEOF);
         if (isset($attributes[0])) {
             /** @var T $object */
             $object = $attributes[0]->newInstance();
@@ -90,7 +90,7 @@ final class AttributeReader implements Reader
      */
     public function getMethodAnnotation(ReflectionMethod $method, $annotationName): ?object
     {
-        $attributes = $method->getAttributes($annotationName);
+        $attributes = $method->getAttributes($annotationName, ReflectionAttribute::IS_INSTANCEOF);
         if (isset($attributes[0])) {
             /** @var T $object */
             $object = $attributes[0]->newInstance();
@@ -130,7 +130,7 @@ final class AttributeReader implements Reader
      */
     public function getPropertyAnnotation(ReflectionProperty $property, $annotationName): ?object
     {
-        $attributes = $property->getAttributes($annotationName);
+        $attributes = $property->getAttributes($annotationName, ReflectionAttribute::IS_INSTANCEOF);
         if (isset($attributes[0])) {
             /** @var T $object */
             $object = $attributes[0]->newInstance();

--- a/tests-php8/AttributeReaderTest.php
+++ b/tests-php8/AttributeReaderTest.php
@@ -76,13 +76,13 @@ class AttributeReaderTest extends TestCase
     {
         $class = new ReflectionClass($this->target);
         $classAnnotation = $this->reader->getClassAnnotation($class, AbstractFoo::class);
-        $this->assertInstanceOf( AbstractFoo::class, $classAnnotation);
+        $this->assertInstanceOf(AbstractFoo::class, $classAnnotation);
         $method = new ReflectionMethod($this->target, 'setKey');
         $methodAnnotation = $this->reader->getMethodAnnotation($method, AbstractFoo::class);
-        $this->assertInstanceOf( AbstractFoo::class, $methodAnnotation);
+        $this->assertInstanceOf(AbstractFoo::class, $methodAnnotation);
         $prop = new ReflectionProperty($this->target, 'prop');
         $propAnnotation = $this->reader->getPropertyAnnotation($prop, AbstractFoo::class);
-        $this->assertInstanceOf( AbstractFoo::class, $propAnnotation);
+        $this->assertInstanceOf(AbstractFoo::class, $propAnnotation);
     }
 
     public function testGetMethodAnnotation(): void

--- a/tests-php8/AttributeReaderTest.php
+++ b/tests-php8/AttributeReaderTest.php
@@ -6,70 +6,19 @@ namespace Koriym\Attributes;
 
 use Doctrine\Common\Annotations\Reader;
 use Koriym\Attributes\Annotation\AbstractFoo;
-use Koriym\Attributes\Annotation\Cacheable;
-use Koriym\Attributes\Annotation\FakeNotExists;
-use Koriym\Attributes\Annotation\FooClass;
-use Koriym\Attributes\Annotation\FooInterface;
-use Koriym\Attributes\Annotation\HttpCache;
-use Koriym\Attributes\Annotation\Inject;
-use Koriym\Attributes\Annotation\Loggable;
-use Koriym\Attributes\Annotation\NotExists;
-use Koriym\Attributes\Annotation\Transactional;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 use ReflectionMethod;
 use ReflectionProperty;
 
-use function array_map;
-use function assert;
-use function class_exists;
-use function get_class;
-use function interface_exists;
-
 class AttributeReaderTest extends TestCase
 {
-    /** @var class-string */
-    protected $target = Fake::class;
-
     /** @var Reader */
     protected $reader;
 
     protected function setUp(): void
     {
         $this->reader = new AttributeReader();
-    }
-
-    public function testIsInstanceOfAttributes(): void
-    {
-        $actual = $this->reader;
-        $this->assertInstanceOf(AttributeReader::class, $actual);
-    }
-
-    public function testGetClassAnnotation(): void
-    {
-        $class = new ReflectionClass($this->target);
-        $annotationName = Cacheable::class;
-        assert(class_exists($annotationName));
-        $cacheable = $this->reader->getClassAnnotation($class, $annotationName);
-        $this->assertInstanceOf(Cacheable::class, $cacheable);
-        $this->assertNull($this->reader->getClassAnnotation($class, FakeNotExists::class));
-    }
-
-    public function testGetClassAnnotations(): void
-    {
-        $class = new ReflectionClass($this->target);
-        $attributes = $this->reader->getClassAnnotations($class);
-        $actural = array_map(static function (object $attribute): string {
-            return get_class($attribute);
-        }, $attributes);
-        $expected = [FooClass::class, Cacheable::class];
-        $this->assertEqualsCanonicalizing($expected, $actural);
-    }
-
-    public function testGetClassAnnotationNotFound(): void
-    {
-        $class = new ReflectionClass($this->target);
-        $this->assertNull($this->reader->getClassAnnotation($class, NotExists::class));
     }
 
     public function testGetAbstractAnnotation(): void
@@ -83,82 +32,5 @@ class AttributeReaderTest extends TestCase
         $prop = new ReflectionProperty(Fake::class, 'prop');
         $propAnnotation = $this->reader->getPropertyAnnotation($prop, AbstractFoo::class);
         $this->assertInstanceOf(AbstractFoo::class, $propAnnotation);
-    }
-
-    public function testGetMethodAnnotation(): void
-    {
-        $method = new ReflectionMethod($this->target, 'subscribe');
-        $annotationName = HttpCache::class;
-        assert(class_exists($annotationName));
-        $cacheable = $this->reader->getMethodAnnotation($method, $annotationName);
-        $this->assertInstanceOf($annotationName, $cacheable);
-        $this->assertNull($this->reader->getMethodAnnotation($method, FakeNotExists::class));
-    }
-
-    public function testGetMethodAnnotations(): void
-    {
-        $method = new ReflectionMethod($this->target, 'subscribe');
-        $attributes = $this->reader->getMethodAnnotations($method);
-        $actural = array_map(static function (object $attribute): string {
-            return get_class($attribute);
-        }, $attributes);
-        $expected = [Loggable::class, HttpCache::class, Transactional::class];
-        $this->assertEqualsCanonicalizing($expected, $actural);
-    }
-
-    public function testGetMethodAnnotationNotFound(): void
-    {
-        $method = new ReflectionMethod($this->target, 'subscribe');
-        $this->assertNull($this->reader->getMethodAnnotation($method, NotExists::class));
-    }
-
-    public function testGetPropertyAnnotation(): void
-    {
-        $prop = new ReflectionProperty($this->target, 'prop');
-        $annotationName = Inject::class;
-        assert(class_exists($annotationName));
-        $cacheable = $this->reader->getPropertyAnnotation($prop, $annotationName);
-        $this->assertInstanceOf($annotationName, $cacheable);
-        $this->assertNull($this->reader->getPropertyAnnotation($prop, FakeNotExists::class));
-    }
-
-    public function testGetPropertyAnnotations(): void
-    {
-        $prop = new ReflectionProperty($this->target, 'prop');
-        $attributes = $this->reader->getPropertyAnnotations($prop);
-        $actural = array_map(static function (object $attribute): string {
-            return get_class($attribute);
-        }, $attributes);
-        $expected = [Inject::class, FooClass::class];
-        $this->assertEqualsCanonicalizing($expected, $actural);
-    }
-
-    public function testGetPropertyAnnotationNotFound(): void
-    {
-        $prop = new ReflectionProperty($this->target, 'prop');
-        $this->assertNull($this->reader->getPropertyAnnotation($prop, NotExists::class));
-    }
-
-    public function testReadIneterfaceInClass(): void
-    {
-        $class = new ReflectionClass(FakeInterfaceRead::class);
-        $annotation = $this->reader->getClassAnnotation($class, FooInterface::class);
-        $this->assertInstanceOf(FooClass::class, $annotation);
-    }
-
-    public function testReadIneterfaceInMethod(): void
-    {
-        $method = new ReflectionMethod(FakeInterfaceRead::class, 'subscribe');
-        $annotation = $this->reader->getMethodAnnotation($method, FooInterface::class);
-        $this->assertInstanceOf(FooClass::class, $annotation);
-        $noAttributeMethod = new ReflectionMethod(FakeInterfaceRead::class, 'noAttribute');
-        $this->assertNull($this->reader->getMethodAnnotation($noAttributeMethod, FooInterface::class));
-    }
-
-    public function testReadIneterfaceInProperty(): void
-    {
-        $class = new ReflectionProperty(FakeInterfaceRead::class, 'prop');
-        $annotation = $this->reader->getPropertyAnnotation($class, FooInterface::class);
-        $this->assertInstanceOf(FooClass::class, $annotation);
     }
 }

--- a/tests-php8/AttributeReaderTest.php
+++ b/tests-php8/AttributeReaderTest.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace Koriym\Attributes;
 
 use Doctrine\Common\Annotations\Reader;
+use Koriym\Attributes\Annotation\AbstractFoo;
 use Koriym\Attributes\Annotation\Cacheable;
+use Koriym\Attributes\Annotation\FakeNotExists;
 use Koriym\Attributes\Annotation\FooClass;
 use Koriym\Attributes\Annotation\FooInterface;
 use Koriym\Attributes\Annotation\HttpCache;
@@ -68,6 +70,19 @@ class AttributeReaderTest extends TestCase
     {
         $class = new ReflectionClass($this->target);
         $this->assertNull($this->reader->getClassAnnotation($class, NotExists::class));
+    }
+
+    public function testGetAbstractAnnotation(): void
+    {
+        $class = new ReflectionClass($this->target);
+        $classAnnotation = $this->reader->getClassAnnotation($class, AbstractFoo::class);
+        $this->assertInstanceOf( AbstractFoo::class, $classAnnotation);
+        $method = new ReflectionMethod($this->target, 'setKey');
+        $methodAnnotation = $this->reader->getMethodAnnotation($method, AbstractFoo::class);
+        $this->assertInstanceOf( AbstractFoo::class, $methodAnnotation);
+        $prop = new ReflectionProperty($this->target, 'prop');
+        $propAnnotation = $this->reader->getPropertyAnnotation($prop, AbstractFoo::class);
+        $this->assertInstanceOf( AbstractFoo::class, $propAnnotation);
     }
 
     public function testGetMethodAnnotation(): void

--- a/tests-php8/AttributeReaderTest.php
+++ b/tests-php8/AttributeReaderTest.php
@@ -74,13 +74,13 @@ class AttributeReaderTest extends TestCase
 
     public function testGetAbstractAnnotation(): void
     {
-        $class = new ReflectionClass($this->target);
+        $class = new ReflectionClass(Fake::class);
         $classAnnotation = $this->reader->getClassAnnotation($class, AbstractFoo::class);
         $this->assertInstanceOf(AbstractFoo::class, $classAnnotation);
-        $method = new ReflectionMethod($this->target, 'setKey');
+        $method = new ReflectionMethod(Fake::class, 'setKey');
         $methodAnnotation = $this->reader->getMethodAnnotation($method, AbstractFoo::class);
         $this->assertInstanceOf(AbstractFoo::class, $methodAnnotation);
-        $prop = new ReflectionProperty($this->target, 'prop');
+        $prop = new ReflectionProperty(Fake::class, 'prop');
         $propAnnotation = $this->reader->getPropertyAnnotation($prop, AbstractFoo::class);
         $this->assertInstanceOf(AbstractFoo::class, $propAnnotation);
     }

--- a/tests-php8/CompatibilityTest.php
+++ b/tests-php8/CompatibilityTest.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Koriym\Attributes;
+
+use Doctrine\Common\Annotations\Reader;
+use Koriym\Attributes\Annotation\Cacheable;
+use Koriym\Attributes\Annotation\FakeNotExists;
+use Koriym\Attributes\Annotation\FooClass;
+use Koriym\Attributes\Annotation\FooInterface;
+use Koriym\Attributes\Annotation\HttpCache;
+use Koriym\Attributes\Annotation\Inject;
+use Koriym\Attributes\Annotation\Loggable;
+use Koriym\Attributes\Annotation\NotExists;
+use Koriym\Attributes\Annotation\Transactional;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use ReflectionMethod;
+use ReflectionProperty;
+
+use function array_map;
+use function assert;
+use function class_exists;
+use function get_class;
+
+class CompatibilityTest extends TestCase
+{
+    /** @var class-string */
+    protected $target = Fake::class;
+
+    /** @var Reader */
+    protected $reader;
+
+    protected function setUp(): void
+    {
+        $this->reader = new AttributeReader();
+    }
+
+    public function testIsInstanceOfAttributes(): void
+    {
+        $actual = $this->reader;
+        $this->assertInstanceOf(AttributeReader::class, $actual);
+    }
+
+    public function testGetClassAnnotation(): void
+    {
+        $class = new ReflectionClass($this->target);
+        $annotationName = Cacheable::class;
+        assert(class_exists($annotationName));
+        $cacheable = $this->reader->getClassAnnotation($class, $annotationName);
+        $this->assertInstanceOf(Cacheable::class, $cacheable);
+        $this->assertNull($this->reader->getClassAnnotation($class, FakeNotExists::class));
+    }
+
+    public function testGetClassAnnotations(): void
+    {
+        $class = new ReflectionClass($this->target);
+        $attributes = $this->reader->getClassAnnotations($class);
+        $actural = array_map(static function (object $attribute): string {
+            return get_class($attribute);
+        }, $attributes);
+        $expected = [FooClass::class, Cacheable::class];
+        $this->assertEqualsCanonicalizing($expected, $actural);
+    }
+
+    public function testGetClassAnnotationNotFound(): void
+    {
+        $class = new ReflectionClass($this->target);
+        $this->assertNull($this->reader->getClassAnnotation($class, NotExists::class));
+    }
+
+    public function testGetMethodAnnotation(): void
+    {
+        $method = new ReflectionMethod($this->target, 'subscribe');
+        $annotationName = HttpCache::class;
+        assert(class_exists($annotationName));
+        $cacheable = $this->reader->getMethodAnnotation($method, $annotationName);
+        $this->assertInstanceOf($annotationName, $cacheable);
+        $this->assertNull($this->reader->getMethodAnnotation($method, FakeNotExists::class));
+    }
+
+    public function testGetMethodAnnotations(): void
+    {
+        $method = new ReflectionMethod($this->target, 'subscribe');
+        $attributes = $this->reader->getMethodAnnotations($method);
+        $actural = array_map(static function (object $attribute): string {
+            return get_class($attribute);
+        }, $attributes);
+        $expected = [Loggable::class, HttpCache::class, Transactional::class];
+        $this->assertEqualsCanonicalizing($expected, $actural);
+    }
+
+    public function testGetMethodAnnotationNotFound(): void
+    {
+        $method = new ReflectionMethod($this->target, 'subscribe');
+        $this->assertNull($this->reader->getMethodAnnotation($method, NotExists::class));
+    }
+
+    public function testGetPropertyAnnotation(): void
+    {
+        $prop = new ReflectionProperty($this->target, 'prop');
+        $annotationName = Inject::class;
+        assert(class_exists($annotationName));
+        $cacheable = $this->reader->getPropertyAnnotation($prop, $annotationName);
+        $this->assertInstanceOf($annotationName, $cacheable);
+        $this->assertNull($this->reader->getPropertyAnnotation($prop, FakeNotExists::class));
+    }
+
+    public function testGetPropertyAnnotations(): void
+    {
+        $prop = new ReflectionProperty($this->target, 'prop');
+        $attributes = $this->reader->getPropertyAnnotations($prop);
+        $actural = array_map(static function (object $attribute): string {
+            return get_class($attribute);
+        }, $attributes);
+        $expected = [Inject::class, FooClass::class];
+        $this->assertEqualsCanonicalizing($expected, $actural);
+    }
+
+    public function testGetPropertyAnnotationNotFound(): void
+    {
+        $prop = new ReflectionProperty($this->target, 'prop');
+        $this->assertNull($this->reader->getPropertyAnnotation($prop, NotExists::class));
+    }
+
+    public function testReadIneterfaceInClass(): void
+    {
+        $class = new ReflectionClass(FakeInterfaceRead::class);
+        $annotation = $this->reader->getClassAnnotation($class, FooInterface::class);
+        $this->assertInstanceOf(FooClass::class, $annotation);
+    }
+
+    public function testReadIneterfaceInMethod(): void
+    {
+        $method = new ReflectionMethod(FakeInterfaceRead::class, 'subscribe');
+        $annotation = $this->reader->getMethodAnnotation($method, FooInterface::class);
+        $this->assertInstanceOf(FooClass::class, $annotation);
+        $noAttributeMethod = new ReflectionMethod(FakeInterfaceRead::class, 'noAttribute');
+        $this->assertNull($this->reader->getMethodAnnotation($noAttributeMethod, FooInterface::class));
+    }
+
+    public function testReadIneterfaceInProperty(): void
+    {
+        $class = new ReflectionProperty(FakeInterfaceRead::class, 'prop');
+        $annotation = $this->reader->getPropertyAnnotation($class, FooInterface::class);
+        $this->assertInstanceOf(FooClass::class, $annotation);
+    }
+}

--- a/tests/DualReaderTest.php
+++ b/tests/DualReaderTest.php
@@ -9,7 +9,7 @@ use Doctrine\Common\Annotations\AnnotationReader;
 /**
  * Inherit all test of AttributeReaferTest
  */
-class DualReaderTest extends AttributeReaderTest
+class DualReaderTest extends CompatibilityTest
 {
     /** @var class-string */
     protected $target = FakeDual::class;

--- a/tests/Fake/Annotation/AbstractFoo.php
+++ b/tests/Fake/Annotation/AbstractFoo.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Koriym\Attributes\Annotation;
+
+abstract class AbstractFoo
+{
+}

--- a/tests/Fake/Annotation/FakeNotExists.php
+++ b/tests/Fake/Annotation/FakeNotExists.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Koriym\Attributes;
+namespace Koriym\Attributes\Annotation;
 
 use Attribute;
 

--- a/tests/Fake/Annotation/FooClass.php
+++ b/tests/Fake/Annotation/FooClass.php
@@ -9,6 +9,6 @@ use Attribute;
  * @Annotation
  */
 #[Attribute]
-final class FooClass implements FooInterface
+final class FooClass extends AbstractFoo implements FooInterface
 {
 }

--- a/tests/Fake/Fake.php
+++ b/tests/Fake/Fake.php
@@ -23,6 +23,7 @@ class Fake
     public string $prop;
 
     #[Inject]
+    #[FooClass]
     public function setKey(#[Named('auth_key')] string $authKey): void // named binding
     {
     }


### PR DESCRIPTION
* Fix the issue that abstract classes are unreadable, which makes them incompatible with annotation readers.

