### PR TITLE
fix: prevent nesting error by skipping merge when no annotations exist

### DIFF
--- a/src/DualReader.php
+++ b/src/DualReader.php
@@ -45,6 +45,10 @@ final class DualReader implements Reader
 
         $attributes = $this->attributeReader->getMethodAnnotations($method);
 
+        if (count($annotations) === 0) {
+            return $attributes;
+        }
+
         return array_unique(array_merge($annotations, $attributes), SORT_REGULAR);
     }
 
@@ -65,6 +69,10 @@ final class DualReader implements Reader
 
         $attributes = $this->attributeReader->getClassAnnotations($class);
 
+        if (count($annotations) === 0) {
+            return $attributes;
+        }
+
         return array_unique(array_merge($annotations, $attributes), SORT_REGULAR);
     }
 
@@ -79,6 +87,10 @@ final class DualReader implements Reader
         }
 
         $attributes = $this->attributeReader->getPropertyAnnotations($property);
+
+        if (count($annotations) === 0) {
+            return $attributes;
+        }
 
         return array_unique(array_merge($annotations, $attributes), SORT_REGULAR);
     }


### PR DESCRIPTION
resolves #26

## Summary by Sourcery

Bug Fixes:
- Skip merging annotation arrays when no docblock annotations are found to prevent nesting errors in method, class, and property readers

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of annotation retrieval to ensure only attribute-based annotations are returned when no annotation-based annotations are present, reducing unnecessary processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->