### PR TITLE
Add parameter attribute reading support

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ $specificAttribute = $reader->getMethodAnnotation($reflection, MyAttribute::clas
 // Read property attributes
 $propertyAttributes = $reader->getPropertyAnnotations($reflection);
 $specificAttribute = $reader->getPropertyAnnotation($reflection, MyAttribute::class);
+
+// Read parameter attributes
+$parameterAttributes = $reader->getParameterAnnotations($reflection);
+$specificAttribute = $reader->getParameterAnnotation($reflection, MyAttribute::class);
 ```
 
 ## Migration Guide

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -39,6 +39,8 @@
         <exclude name="SlevomatCodingStandard.ControlStructures.EarlyExit.EarlyExitNotUsed"/>
         <exclude name="SlevomatCodingStandard.PHP.RequireExplicitAssertion.RequiredExplicitAssertion"/>
         <exclude name="SlevomatCodingStandard.Functions.RequireTrailingCommaInCall.MissingTrailingComma"/>
+        <exclude name="SlevomatCodingStandard.TypeHints.UnionTypeHintFormat"/>
+        <exclude name="Squiz.WhiteSpace.LanguageConstructSpacing"/>
     </rule>
 
     <!-- Additional Rules -->

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -40,7 +40,6 @@
         <exclude name="SlevomatCodingStandard.PHP.RequireExplicitAssertion.RequiredExplicitAssertion"/>
         <exclude name="SlevomatCodingStandard.Functions.RequireTrailingCommaInCall.MissingTrailingComma"/>
         <exclude name="SlevomatCodingStandard.TypeHints.UnionTypeHintFormat"/>
-        <exclude name="Squiz.WhiteSpace.LanguageConstructSpacing"/>
     </rule>
 
     <!-- Additional Rules -->

--- a/src/AttributeReader.php
+++ b/src/AttributeReader.php
@@ -7,6 +7,7 @@ namespace Koriym\Attributes;
 use ReflectionAttribute;
 use ReflectionClass;
 use ReflectionMethod;
+use ReflectionParameter;
 use ReflectionProperty;
 
 final class AttributeReader implements AttributeReaderInterface
@@ -94,6 +95,35 @@ final class AttributeReader implements AttributeReaderInterface
     public function getPropertyAnnotation(ReflectionProperty $property, string $annotationName): object|null
     {
         $attributes = $property->getAttributes($annotationName, ReflectionAttribute::IS_INSTANCEOF);
+        if (isset($attributes[0])) {
+            return $attributes[0]->newInstance();
+        }
+
+        return null;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getParameterAnnotations(ReflectionParameter $param): array
+    {
+        $attributes = $param->getAttributes();
+        $instances = [];
+        foreach ($attributes as $attribute) {
+            $instances[] = $attribute->newInstance();
+        }
+
+        return $instances;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @template T of object
+     */
+    public function getParameterAnnotation(ReflectionParameter $param, string $annotation): object|null
+    {
+        $attributes = $param->getAttributes($annotation);
         if (isset($attributes[0])) {
             return $attributes[0]->newInstance();
         }

--- a/src/AttributeReaderInterface.php
+++ b/src/AttributeReaderInterface.php
@@ -6,6 +6,7 @@ namespace Koriym\Attributes;
 
 use ReflectionClass;
 use ReflectionMethod;
+use ReflectionParameter;
 use ReflectionProperty;
 
 interface AttributeReaderInterface
@@ -66,4 +67,27 @@ interface AttributeReaderInterface
      * @template T of object
      */
     public function getPropertyAnnotation(ReflectionProperty $property, string $annotationName): object|null;
+
+    /**
+     * Gets the attributes applied to a method parameter.
+     *
+     * @param ReflectionParameter $param The ReflectionParameter of the parameter
+     *                                   from which the attributes should be read.
+     *
+     * @return array<object> An array of Annotations/Attributes.
+     */
+    public function getParameterAnnotations(ReflectionParameter $param): array;
+
+    /**
+     * Gets a method parameter attribute
+     *
+     * @param ReflectionParameter $param      The ReflectionParameter of the parameter
+     *                                        from which the attributes should be read.
+     * @param class-string<T>     $annotation
+     *
+     * @return T|null The Annotation/Attribute or NULL, if the requested annotation does not exist.
+     *
+     * @template T of object
+     */
+    public function getParameterAnnotation(ReflectionParameter $param, string $annotation): object|null;
 }

--- a/tests/AttributeReader/AttributeReaderTest.php
+++ b/tests/AttributeReader/AttributeReaderTest.php
@@ -16,6 +16,7 @@ use Koriym\Attributes\Tests\Fake\FakeDual;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 use ReflectionMethod;
+use ReflectionParameter;
 use ReflectionProperty;
 
 use function array_map;
@@ -34,6 +35,9 @@ final class AttributeReaderTest extends TestCase
     /** @var ReflectionProperty */
     private $reflectionProperty;
 
+    /** @var ReflectionParameter */
+    private $reflectionParameter;
+
     protected function setUp(): void
     {
         $this->attributeReader = new AttributeReader();
@@ -41,6 +45,7 @@ final class AttributeReaderTest extends TestCase
         $this->reflectionClass = new ReflectionClass(FakeDual::class);
         $this->reflectionMethod = new ReflectionMethod(FakeDual::class, 'subscribe');
         $this->reflectionProperty = new ReflectionProperty(FakeDual::class, 'prop');
+        $this->reflectionParameter = new ReflectionParameter([FakeDual::class, 'subscribe'], 'id');
     }
 
     public function testClass(): void
@@ -96,6 +101,22 @@ final class AttributeReaderTest extends TestCase
         $this->assertEqualsCanonicalizing($expectedAttributeClasses, $foundAttributeClasses);
     }
 
+    public function testParameter(): void
+    {
+        $foundAttribute = $this->attributeReader->getParameterAnnotation($this->reflectionParameter, FakeLoggable::class);
+        $this->assertInstanceOf(FakeLoggable::class, $foundAttribute);
+    }
+
+    public function testParameters(): void
+    {
+        $foundAttributes = $this->attributeReader->getParameterAnnotations($this->reflectionParameter);
+
+        $foundAttributeClasses = $this->resolveAttributeClasses($foundAttributes);
+        $expectedAttributeClasses = [FakeLoggable::class, FakeInject::class];
+
+        $this->assertEqualsCanonicalizing($expectedAttributeClasses, $foundAttributeClasses);
+    }
+
     public function testMissingAnnotations(): void
     {
         $this->assertNull($this->attributeReader->getClassAnnotation($this->reflectionClass, FakeNotExists::class));
@@ -106,6 +127,8 @@ final class AttributeReaderTest extends TestCase
         ));
 
         $this->assertNull($this->attributeReader->getPropertyAnnotation($this->reflectionProperty, FakeNotExists::class));
+
+        $this->assertNull($this->attributeReader->getParameterAnnotation($this->reflectionParameter, FakeNotExists::class));
     }
 
     /**

--- a/tests/Fake/FakeDual.php
+++ b/tests/Fake/FakeDual.php
@@ -34,7 +34,7 @@ class FakeDual
      */
     #[FakeInject]
     #[FakeFooClass]
-    public function setKey(string $authKey): void // named binding
+    public function setKey(#[FakeInject] string $authKey): void // named binding
     {
     }
 
@@ -46,7 +46,7 @@ class FakeDual
     #[FakeTransactional]
     #[FakeLoggable]
     #[FakeHttpCache(isPrivate: true, maxAge: 50)]
-    public function subscribe(string $id): void  // intercepted
+    public function subscribe(#[FakeLoggable] #[FakeInject] string $id): void  // intercepted
     {
     }
 }


### PR DESCRIPTION
## Summary

Add support for reading attributes from method/function parameters. This ports functionality from `Koriym.ParamReader` into the main library.

## Changes

- ✅ Add `getParameterAnnotations()` method to read all parameter attributes
- ✅ Add `getParameterAnnotation()` method to read specific parameter attribute
- ✅ Add `ReflectionParameter` import to both interface and implementation
- ✅ Fix uninitialized variable bug in implementation
- ✅ Add proper `isset()` check for array access
- ✅ Add comprehensive test coverage for parameter attributes
- ✅ Suppress deprecated phpcs warnings
- ✅ Update README with parameter attribute examples

## Test Plan

- [x] All existing tests pass (15 tests, 18 assertions)
- [x] New parameter attribute tests added and passing
- [x] PHPStan: No errors
- [x] Psalm: No errors (100% type inference)
- [x] PHPCS: Clean

## Related

This is a port from `Koriym.ParamReader` functionality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Sourceryによる概要

インターフェースと実装に新しいメソッドを追加し、関連バグの修正、テストカバレッジの追加、ドキュメントの更新、コーディング規約設定の調整を行うことで、パラメータ属性の読み取りに対する完全なサポートを導入します。

新機能:
- メソッド/関数のパラメータからすべての属性または特定の属性を読み取るための `getParameterAnnotations` メソッドと `getParameterAnnotation` メソッドを追加

バグ修正:
- パラメータ属性リーダーの実装における未初期化変数を修正
- 属性配列へのアクセス時にエラーを防ぐため `isset()` チェックを追加

改善点:
- `phpcs.xml` で非推奨の追加のPHPCS警告を抑制

ドキュメント:
- パラメータ属性の読み取り例を含む `README` を更新

テスト:
- 単一および複数の属性の両方のパラメータ属性取得をカバーするテストを追加

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce full support for parameter attribute reading by extending the interface and implementation with new methods, fixing related bugs, adding test coverage, updating documentation, and adjusting coding standards configuration.

New Features:
- Add getParameterAnnotations and getParameterAnnotation methods to read all or specific attributes from method/function parameters

Bug Fixes:
- Fix uninitialized variable in the parameter attribute reader implementation
- Add isset() check to prevent errors when accessing attributes array

Enhancements:
- Suppress additional deprecated PHPCS warnings in phpcs.xml

Documentation:
- Update README with examples for reading parameter attributes

Tests:
- Add tests covering parameter attribute retrieval for both single and multiple attributes

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for reading and retrieving attributes defined at the parameter level on methods and functions.

* **Tests**
  * Extended test coverage to verify parameter-level attribute reading functionality.

* **Chores**
  * Updated coding standards configuration to exclude specific linting rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->