### PR TITLE
Rename methods from Annotation to Attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,24 +42,24 @@ use Koriym\Attributes\AttributeReaderInterface;
 $reader = new AttributeReader();
 ```
 
-The reader provides methods for reading PHP 8 attributes with the familiar Reader interface:
+The reader provides methods for reading PHP 8 attributes:
 
 ```php
 // Read class attributes
-$classAttributes = $reader->getClassAnnotations($reflection);
-$specificAttribute = $reader->getClassAnnotation($reflection, MyAttribute::class);
+$classAttributes = $reader->getClassAttributes($reflection);
+$specificAttribute = $reader->getClassAttribute($reflection, MyAttribute::class);
 
 // Read method attributes
-$methodAttributes = $reader->getMethodAnnotations($reflection);
-$specificAttribute = $reader->getMethodAnnotation($reflection, MyAttribute::class);
+$methodAttributes = $reader->getMethodAttributes($reflection);
+$specificAttribute = $reader->getMethodAttribute($reflection, MyAttribute::class);
 
 // Read property attributes
-$propertyAttributes = $reader->getPropertyAnnotations($reflection);
-$specificAttribute = $reader->getPropertyAnnotation($reflection, MyAttribute::class);
+$propertyAttributes = $reader->getPropertyAttributes($reflection);
+$specificAttribute = $reader->getPropertyAttribute($reflection, MyAttribute::class);
 
 // Read parameter attributes
-$parameterAttributes = $reader->getParameterAnnotations($reflection);
-$specificAttribute = $reader->getParameterAnnotation($reflection, MyAttribute::class);
+$parameterAttributes = $reader->getParameterAttributes($reflection);
+$specificAttribute = $reader->getParameterAttribute($reflection, MyAttribute::class);
 ```
 
 ## Migration Guide
@@ -116,24 +116,24 @@ If your codebase currently uses `Doctrine\Common\Annotations\Reader`, you can mi
 }
 ```
 
-**If you have custom implementations** of the reader interface, add explicit `string` type:
+**If you have custom implementations** of the reader interface, update method names:
 
 ```diff
  use Koriym\Attributes\AttributeReaderInterface;
 
  class MyCustomReader implements AttributeReaderInterface
  {
--    public function getClassAnnotation(ReflectionClass $class, $annotationName): object|null
-+    public function getClassAnnotation(ReflectionClass $class, string $annotationName): object|null
+-    public function getClassAnnotation(ReflectionClass $class, string $annotationName): object|null
++    public function getClassAttribute(ReflectionClass $class, string $attributeName): object|null
      {
          // your implementation
      }
 
-+    // Same for getMethodAnnotation() and getPropertyAnnotation()
++    // Same for getMethodAttribute() and getPropertyAttribute()
  }
 ```
 
-For most users (those consuming the interface, not implementing it), your existing code continues to work without changes.
+For most users (those consuming the interface, not implementing it), you need to update method calls from `getXxxAnnotation()` to `getXxxAttribute()`.
 
 ## For Library Authors
 

--- a/rector-migrate.php
+++ b/rector-migrate.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
  * This configuration automates:
  * 1. Class name changes from Doctrine Annotations to Koriym AttributeReaderInterface
  * 2. Doctrine annotations (@Annotation) to PHP 8 attributes (#[Attribute])
+ * 3. Method name changes from getXxxAnnotation(s) to getXxxAttribute(s)
  *
  * Usage:
  *   1. Install Rector and Doctrine rules:
@@ -15,21 +16,32 @@ declare(strict_types=1);
  *   2. Customize paths in this file to match your project structure
  *   3. Run: vendor/bin/rector process --config=rector-migrate.php
  *   4. Review changes and run tests
- *   5. If you have custom implementations, manually add 'string' type to $annotationName
+ *   5. If you have custom implementations, manually update method names
  *   6. Optional: Remove Rector after migration
  *
  * What this does:
  * - Converts @Route("/api") to #[Route("/api")]
  * - Converts Reader to AttributeReaderInterface
  * - Converts DualReader to AttributeReader
+ * - Renames getClassAnnotations() to getClassAttributes()
+ * - Renames getClassAnnotation() to getClassAttribute()
+ * - Renames getMethodAnnotations() to getMethodAttributes()
+ * - Renames getMethodAnnotation() to getMethodAttribute()
+ * - Renames getPropertyAnnotations() to getPropertyAttributes()
+ * - Renames getPropertyAnnotation() to getPropertyAttribute()
+ * - Renames getParameterAnnotations() to getParameterAttributes()
+ * - Renames getParameterAnnotation() to getParameterAttribute()
  *
  * @see https://github.com/koriym/Koriym.Attributes
  * @see https://www.doctrine-project.org/2022/11/04/annotations-to-attributes.html (Doctrine's migration guide)
  */
 
+use Koriym\Attributes\AttributeReaderInterface;
 use Rector\Config\RectorConfig;
 use Rector\Doctrine\Set\DoctrineSetList;
+use Rector\Renaming\Rector\MethodCall\RenameMethodRector;
 use Rector\Renaming\Rector\Name\RenameClassRector;
+use Rector\Renaming\ValueObject\MethodCallRename;
 
 return RectorConfig::configure()
     ->withPaths([
@@ -55,6 +67,20 @@ return RectorConfig::configure()
 
             // Replace DualReader with AttributeReader (1.x to 2.x migration)
             'Koriym\Attributes\DualReader' => 'Koriym\Attributes\AttributeReader',
+        ]
+    )
+    ->withConfiguredRule(
+        RenameMethodRector::class,
+        [
+            // Rename getXxxAnnotation(s) methods to getXxxAttribute(s)
+            new MethodCallRename(AttributeReaderInterface::class, 'getClassAnnotations', 'getClassAttributes'),
+            new MethodCallRename(AttributeReaderInterface::class, 'getClassAnnotation', 'getClassAttribute'),
+            new MethodCallRename(AttributeReaderInterface::class, 'getMethodAnnotations', 'getMethodAttributes'),
+            new MethodCallRename(AttributeReaderInterface::class, 'getMethodAnnotation', 'getMethodAttribute'),
+            new MethodCallRename(AttributeReaderInterface::class, 'getPropertyAnnotations', 'getPropertyAttributes'),
+            new MethodCallRename(AttributeReaderInterface::class, 'getPropertyAnnotation', 'getPropertyAttribute'),
+            new MethodCallRename(AttributeReaderInterface::class, 'getParameterAnnotations', 'getParameterAttributes'),
+            new MethodCallRename(AttributeReaderInterface::class, 'getParameterAnnotation', 'getParameterAttribute'),
         ]
     )
     ->withPhpSets(php81: true);

--- a/src/AttributeReader.php
+++ b/src/AttributeReader.php
@@ -15,23 +15,7 @@ final class AttributeReader implements AttributeReaderInterface
     /**
      * {@inheritDoc}
      */
-    public function getMethodAnnotations(ReflectionMethod $method): array
-    {
-        $attributesRefs = $method->getAttributes();
-        $attributes = [];
-        foreach ($attributesRefs as $ref) {
-            $attributes[] = $ref->newInstance();
-        }
-
-        return $attributes;
-    }
-
-    /**
-     * @param ReflectionClass<object> $class
-     *
-     * @return array<object>
-     */
-    public function getClassAnnotations(ReflectionClass $class): array
+    public function getClassAttributes(ReflectionClass $class): array
     {
         $attributesRefs = $class->getAttributes();
         $attributes = [];
@@ -48,14 +32,28 @@ final class AttributeReader implements AttributeReaderInterface
      *
      * @template T of object
      */
-    public function getClassAnnotation(ReflectionClass $class, string $annotationName): object|null
+    public function getClassAttribute(ReflectionClass $class, string $attributeName): object|null
     {
-        $attributes = $class->getAttributes($annotationName, ReflectionAttribute::IS_INSTANCEOF);
+        $attributes = $class->getAttributes($attributeName, ReflectionAttribute::IS_INSTANCEOF);
         if (isset($attributes[0])) {
             return $attributes[0]->newInstance();
         }
 
         return null;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getMethodAttributes(ReflectionMethod $method): array
+    {
+        $attributesRefs = $method->getAttributes();
+        $attributes = [];
+        foreach ($attributesRefs as $ref) {
+            $attributes[] = $ref->newInstance();
+        }
+
+        return $attributes;
     }
 
     /**
@@ -63,9 +61,9 @@ final class AttributeReader implements AttributeReaderInterface
      *
      * @template T of object
      */
-    public function getMethodAnnotation(ReflectionMethod $method, string $annotationName): object|null
+    public function getMethodAttribute(ReflectionMethod $method, string $attributeName): object|null
     {
-        $attributes = $method->getAttributes($annotationName, ReflectionAttribute::IS_INSTANCEOF);
+        $attributes = $method->getAttributes($attributeName, ReflectionAttribute::IS_INSTANCEOF);
         if (isset($attributes[0])) {
             return $attributes[0]->newInstance();
         }
@@ -76,7 +74,7 @@ final class AttributeReader implements AttributeReaderInterface
     /**
      * {@inheritDoc}
      */
-    public function getPropertyAnnotations(ReflectionProperty $property): array
+    public function getPropertyAttributes(ReflectionProperty $property): array
     {
         $attributesRefs = $property->getAttributes();
         $attributes = [];
@@ -92,9 +90,9 @@ final class AttributeReader implements AttributeReaderInterface
      *
      * @template T of object
      */
-    public function getPropertyAnnotation(ReflectionProperty $property, string $annotationName): object|null
+    public function getPropertyAttribute(ReflectionProperty $property, string $attributeName): object|null
     {
-        $attributes = $property->getAttributes($annotationName, ReflectionAttribute::IS_INSTANCEOF);
+        $attributes = $property->getAttributes($attributeName, ReflectionAttribute::IS_INSTANCEOF);
         if (isset($attributes[0])) {
             return $attributes[0]->newInstance();
         }
@@ -105,7 +103,7 @@ final class AttributeReader implements AttributeReaderInterface
     /**
      * {@inheritDoc}
      */
-    public function getParameterAnnotations(ReflectionParameter $param): array
+    public function getParameterAttributes(ReflectionParameter $param): array
     {
         $attributes = $param->getAttributes();
         $instances = [];
@@ -121,9 +119,9 @@ final class AttributeReader implements AttributeReaderInterface
      *
      * @template T of object
      */
-    public function getParameterAnnotation(ReflectionParameter $param, string $annotation): object|null
+    public function getParameterAttribute(ReflectionParameter $param, string $attributeName): object|null
     {
-        $attributes = $param->getAttributes($annotation);
+        $attributes = $param->getAttributes($attributeName);
         if (isset($attributes[0])) {
             return $attributes[0]->newInstance();
         }

--- a/src/AttributeReaderInterface.php
+++ b/src/AttributeReaderInterface.php
@@ -12,61 +12,61 @@ use ReflectionProperty;
 interface AttributeReaderInterface
 {
     /**
-     * Gets the annotations applied to a class.
+     * Gets the attributes applied to a class.
      *
      * @param ReflectionClass<object> $class
      *
      * @return array<object>
      */
-    public function getClassAnnotations(ReflectionClass $class): array;
+    public function getClassAttributes(ReflectionClass $class): array;
 
     /**
-     * Gets a class annotation.
+     * Gets a class attribute.
      *
      * @param ReflectionClass<object> $class
-     * @param class-string<T>         $annotationName
+     * @param class-string<T>         $attributeName
      *
      * @return T|null
      *
      * @template T of object
      */
-    public function getClassAnnotation(ReflectionClass $class, string $annotationName): object|null;
+    public function getClassAttribute(ReflectionClass $class, string $attributeName): object|null;
 
     /**
-     * Gets the annotations applied to a method.
+     * Gets the attributes applied to a method.
      *
      * @return array<object>
      */
-    public function getMethodAnnotations(ReflectionMethod $method): array;
+    public function getMethodAttributes(ReflectionMethod $method): array;
 
     /**
-     * Gets a method annotation.
+     * Gets a method attribute.
      *
-     * @param class-string<T> $annotationName
+     * @param class-string<T> $attributeName
      *
      * @return T|null
      *
      * @template T of object
      */
-    public function getMethodAnnotation(ReflectionMethod $method, string $annotationName): object|null;
+    public function getMethodAttribute(ReflectionMethod $method, string $attributeName): object|null;
 
     /**
-     * Gets the annotations applied to a property.
+     * Gets the attributes applied to a property.
      *
      * @return array<object>
      */
-    public function getPropertyAnnotations(ReflectionProperty $property): array;
+    public function getPropertyAttributes(ReflectionProperty $property): array;
 
     /**
-     * Gets a property annotation.
+     * Gets a property attribute.
      *
-     * @param class-string<T> $annotationName
+     * @param class-string<T> $attributeName
      *
      * @return T|null
      *
      * @template T of object
      */
-    public function getPropertyAnnotation(ReflectionProperty $property, string $annotationName): object|null;
+    public function getPropertyAttribute(ReflectionProperty $property, string $attributeName): object|null;
 
     /**
      * Gets the attributes applied to a method parameter.
@@ -76,18 +76,18 @@ interface AttributeReaderInterface
      *
      * @return array<object> An array of Annotations/Attributes.
      */
-    public function getParameterAnnotations(ReflectionParameter $param): array;
+    public function getParameterAttributes(ReflectionParameter $param): array;
 
     /**
      * Gets a method parameter attribute
      *
-     * @param ReflectionParameter $param      The ReflectionParameter of the parameter
-     *                                        from which the attributes should be read.
-     * @param class-string<T>     $annotation
+     * @param ReflectionParameter $param         The ReflectionParameter of the parameter
+     *                                           from which the attributes should be read.
+     * @param class-string<T>     $attributeName
      *
      * @return T|null The Annotation/Attribute or NULL, if the requested annotation does not exist.
      *
      * @template T of object
      */
-    public function getParameterAnnotation(ReflectionParameter $param, string $annotation): object|null;
+    public function getParameterAttribute(ReflectionParameter $param, string $attributeName): object|null;
 }

--- a/tests/AttributeReader/AttributeReaderTest.php
+++ b/tests/AttributeReader/AttributeReaderTest.php
@@ -50,13 +50,13 @@ final class AttributeReaderTest extends TestCase
 
     public function testClass(): void
     {
-        $foundAttributes = $this->attributeReader->getClassAnnotation($this->reflectionClass, FakeCacheable::class);
+        $foundAttributes = $this->attributeReader->getClassAttribute($this->reflectionClass, FakeCacheable::class);
         $this->assertInstanceOf(FakeCacheable::class, $foundAttributes);
     }
 
     public function testClasses(): void
     {
-        $foundAttributes = $this->attributeReader->getClassAnnotations($this->reflectionClass);
+        $foundAttributes = $this->attributeReader->getClassAttributes($this->reflectionClass);
 
         $foundAttributeClasses = array_map(static function (object $attribute): string {
             return $attribute::class;
@@ -68,7 +68,7 @@ final class AttributeReaderTest extends TestCase
 
     public function testMethod(): void
     {
-        $foundAttribute = $this->attributeReader->getMethodAnnotation(
+        $foundAttribute = $this->attributeReader->getMethodAttribute(
             $this->reflectionMethod,
             FakeHttpCache::class
         );
@@ -77,7 +77,7 @@ final class AttributeReaderTest extends TestCase
 
     public function testMethods(): void
     {
-        $foundAttributes = $this->attributeReader->getMethodAnnotations($this->reflectionMethod);
+        $foundAttributes = $this->attributeReader->getMethodAttributes($this->reflectionMethod);
 
         $foundAttributeClasses = $this->resolveAttributeClasses($foundAttributes);
         $expectedAttributeClasses = [FakeLoggable::class, FakeHttpCache::class, FakeTransactional::class];
@@ -87,13 +87,13 @@ final class AttributeReaderTest extends TestCase
 
     public function testProperty(): void
     {
-        $foundAttribute = $this->attributeReader->getPropertyAnnotation($this->reflectionProperty, FakeInject::class);
+        $foundAttribute = $this->attributeReader->getPropertyAttribute($this->reflectionProperty, FakeInject::class);
         $this->assertInstanceOf(FakeInject::class, $foundAttribute);
     }
 
     public function testProperties(): void
     {
-        $foundAttributes = $this->attributeReader->getPropertyAnnotations($this->reflectionProperty);
+        $foundAttributes = $this->attributeReader->getPropertyAttributes($this->reflectionProperty);
 
         $foundAttributeClasses = $this->resolveAttributeClasses($foundAttributes);
         $expectedAttributeClasses = [FakeInject::class, FakeFooClass::class];
@@ -103,13 +103,13 @@ final class AttributeReaderTest extends TestCase
 
     public function testParameter(): void
     {
-        $foundAttribute = $this->attributeReader->getParameterAnnotation($this->reflectionParameter, FakeLoggable::class);
+        $foundAttribute = $this->attributeReader->getParameterAttribute($this->reflectionParameter, FakeLoggable::class);
         $this->assertInstanceOf(FakeLoggable::class, $foundAttribute);
     }
 
     public function testParameters(): void
     {
-        $foundAttributes = $this->attributeReader->getParameterAnnotations($this->reflectionParameter);
+        $foundAttributes = $this->attributeReader->getParameterAttributes($this->reflectionParameter);
 
         $foundAttributeClasses = $this->resolveAttributeClasses($foundAttributes);
         $expectedAttributeClasses = [FakeLoggable::class, FakeInject::class];
@@ -119,16 +119,16 @@ final class AttributeReaderTest extends TestCase
 
     public function testMissingAnnotations(): void
     {
-        $this->assertNull($this->attributeReader->getClassAnnotation($this->reflectionClass, FakeNotExists::class));
+        $this->assertNull($this->attributeReader->getClassAttribute($this->reflectionClass, FakeNotExists::class));
 
-        $this->assertNull($this->attributeReader->getMethodAnnotation(
+        $this->assertNull($this->attributeReader->getMethodAttribute(
             $this->reflectionMethod,
             FakeNotExists::class
         ));
 
-        $this->assertNull($this->attributeReader->getPropertyAnnotation($this->reflectionProperty, FakeNotExists::class));
+        $this->assertNull($this->attributeReader->getPropertyAttribute($this->reflectionProperty, FakeNotExists::class));
 
-        $this->assertNull($this->attributeReader->getParameterAnnotation($this->reflectionParameter, FakeNotExists::class));
+        $this->assertNull($this->attributeReader->getParameterAttribute($this->reflectionParameter, FakeNotExists::class));
     }
 
     /**

--- a/tests/AttributeReader/ReadingAbstractAttributeTest.php
+++ b/tests/AttributeReader/ReadingAbstractAttributeTest.php
@@ -36,13 +36,13 @@ final class ReadingAbstractAttributeTest extends TestCase
 
     public function testClassAttribute(): void
     {
-        $classAttribute = $this->attributeReader->getClassAnnotation($this->reflectionClass, FakeAbstractFoo::class);
+        $classAttribute = $this->attributeReader->getClassAttribute($this->reflectionClass, FakeAbstractFoo::class);
         $this->assertInstanceOf(FakeAbstractFoo::class, $classAttribute);
     }
 
     public function testMethodAttribute(): void
     {
-        $methodAttribute = $this->attributeReader->getMethodAnnotation(
+        $methodAttribute = $this->attributeReader->getMethodAttribute(
             $this->methodReflection,
             FakeAbstractFoo::class
         );
@@ -51,7 +51,7 @@ final class ReadingAbstractAttributeTest extends TestCase
 
     public function testPropertyAttribute(): void
     {
-        $propertyAttribute = $this->attributeReader->getPropertyAnnotation($this->propertyReflection, FakeAbstractFoo::class);
+        $propertyAttribute = $this->attributeReader->getPropertyAttribute($this->propertyReflection, FakeAbstractFoo::class);
         $this->assertInstanceOf(FakeAbstractFoo::class, $propertyAttribute);
     }
 }

--- a/tests/AttributeReader/ReadingInterfaceTest.php
+++ b/tests/AttributeReader/ReadingInterfaceTest.php
@@ -38,19 +38,19 @@ final class ReadingInterfaceTest extends TestCase
 
     public function testClassAttribute(): void
     {
-        $classAttribute = $this->attributeReader->getClassAnnotation($this->reflectionClass, FakeFooInterface::class);
+        $classAttribute = $this->attributeReader->getClassAttribute($this->reflectionClass, FakeFooInterface::class);
         $this->assertInstanceOf(FakeFooClass::class, $classAttribute);
     }
 
     public function testReadIneterfaceInMethod(): void
     {
-        $methodAttribute = $this->attributeReader->getMethodAnnotation($this->reflectionMethod, FakeFooInterface::class);
+        $methodAttribute = $this->attributeReader->getMethodAttribute($this->reflectionMethod, FakeFooInterface::class);
         $this->assertInstanceOf(FakeFooClass::class, $methodAttribute);
     }
 
     public function testPropertyAttribute(): void
     {
-        $propertyAttribute = $this->attributeReader->getPropertyAnnotation($this->reflectionProperty, FakeFooInterface::class);
+        $propertyAttribute = $this->attributeReader->getPropertyAttribute($this->reflectionProperty, FakeFooInterface::class);
         $this->assertInstanceOf(FakeFooClass::class, $propertyAttribute);
     }
 }

--- a/vendor-bin/tools/composer.lock
+++ b/vendor-bin/tools/composer.lock
@@ -3998,16 +3998,16 @@
         },
         {
             "name": "webmozart/assert",
-            "version": "1.12.0",
+            "version": "1.12.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webmozarts/assert.git",
-                "reference": "541057574806f942c94662b817a50f63f7345360"
+                "reference": "9be6926d8b485f55b9229203f962b51ed377ba68"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozarts/assert/zipball/541057574806f942c94662b817a50f63f7345360",
-                "reference": "541057574806f942c94662b817a50f63f7345360",
+                "url": "https://api.github.com/repos/webmozarts/assert/zipball/9be6926d8b485f55b9229203f962b51ed377ba68",
+                "reference": "9be6926d8b485f55b9229203f962b51ed377ba68",
                 "shasum": ""
             },
             "require": {
@@ -4050,9 +4050,9 @@
             ],
             "support": {
                 "issues": "https://github.com/webmozarts/assert/issues",
-                "source": "https://github.com/webmozarts/assert/tree/1.12.0"
+                "source": "https://github.com/webmozarts/assert/tree/1.12.1"
             },
-            "time": "2025-10-20T12:43:39+00:00"
+            "time": "2025-10-29T15:56:20+00:00"
         }
     ],
     "aliases": [],


### PR DESCRIPTION
## Summary

**BREAKING CHANGE**: Rename all methods to reflect PHP 8 attributes naming, making the API more accurate as the library now only supports PHP 8 native attributes.

## Changes

### Method Renames
- ✅ `getClassAnnotations()` → `getClassAttributes()`
- ✅ `getClassAnnotation()` → `getClassAttribute()`
- ✅ `getMethodAnnotations()` → `getMethodAttributes()`
- ✅ `getMethodAnnotation()` → `getMethodAttribute()`
- ✅ `getPropertyAnnotations()` → `getPropertyAttributes()`
- ✅ `getPropertyAnnotation()` → `getPropertyAttribute()`
- ✅ `getParameterAnnotations()` → `getParameterAttributes()`
- ✅ `getParameterAnnotation()` → `getParameterAttribute()`

### Parameter Renames
- ✅ `$annotationName` → `$attributeName`

### Additional Updates
- ✅ Updated Rector migration config with method rename rules
- ✅ Updated README with new method names
- ✅ Updated all tests
- ✅ Upgraded to PHPUnit 10 and phpcodesniffer 4.0

## Migration

Use the updated `rector-migrate.php` configuration to automatically rename method calls:

```bash
composer require --dev rector/rector rector/rector-doctrine
vendor/bin/rector process --config=rector-migrate.php
```

## Rationale

The library now only supports PHP 8 native attributes (Doctrine annotations support was removed in 2.x). Using "Annotation" in method names was confusing and inaccurate. This change makes the API more semantic and truthful.

## Test Plan

- [x] All tests pass (15 tests, 18 assertions)
- [x] PHPStan: No errors
- [x] Psalm: No errors (100% type inference)
- [x] PHPCS: Clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Sourceryによる要約

PHP 8のネイティブ属性に合わせるため、パブリックAPIメソッド名を「Annotation」から「Attribute」にリネームし、関連するドキュメント、テスト、移行ツールを更新し、開発依存関係をバージョンアップします。

機能強化:
- コードとインターフェース全体で、`getClass*/getMethod*/getProperty*/getParameter*Annotation(s)` メソッドを`get*Attribute(s)` にリネーム
- メソッドパラメータを`$annotationName`から`$attributeName`にリネーム

ビルド:
- PHPUnit 10にアップグレード
- phpcodesnifferを4.0にアップグレード

ドキュメント:
- READMEの例と移行ガイドを、新しいAttributeメソッド名を使用するように更新

テスト:
- すべてのテストを`get*Attribute`メソッドを参照するように更新

雑務:
- `rector-migrate.php`にRectorのメソッド名変更ルールを追加

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Rename public API methods from "Annotation" to "Attribute" to align with PHP 8 native attributes, update dependent docs, tests and migration tooling, and bump dev dependencies.

Enhancements:
- Rename getClass*/getMethod*/getProperty*/getParameter*Annotation(s) methods to get*Attribute(s) across code and interface
- Rename method parameters from $annotationName to $attributeName

Build:
- Upgrade to PHPUnit 10
- Upgrade phpcodesniffer to 4.0

Documentation:
- Update README examples and migration guide to use new Attribute method names

Tests:
- Update all tests to reference get*Attribute methods

Chores:
- Add Rector method-rename rules to rector-migrate.php

</details>